### PR TITLE
Fix #6: pass \n to sed as ANSI-C quoting

### DIFF
--- a/crawler.sh
+++ b/crawler.sh
@@ -71,7 +71,7 @@ _links_dump() {
     --user-agent="$_USER_AGENT" \
     $_WGET_OPTIONS \
     -O- "$@" \
-  | sed -e "s#['\"]#\n#g" \
+  | sed -e "s#['\"]#\\"$'\n#g' \
   | grep -E '^https?://' \
   | sort -u
 }


### PR DESCRIPTION
BSD version of sed wont interpret '\n' as newline character.
Passing '\n' to sed as ANSI-C quoting would avoid this problem.

ref: http://wiki.bash-hackers.org/syntax/quoting#ansi_c_like_strings